### PR TITLE
Update import models

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -29,7 +29,7 @@
     * [🔗 Main Website](https://runwayml.com/)
     * [🔗 Support](https://support.runwayml.com/)
     * [🔗 Your Account](https://account.runwayml.com/)
-    * [🔗 Slack](https://runwayml.com/joinslack)
+    * [🔗 Join Our Slack](https://runwayml.com/joinslack)
     * [🔗 Github](https://github.com/runwayml)
     * [🔗 Video Tutorials](https://www.youtube.com/runwayml)
     * [🔗 Runway on Linux](https://support.runwayml.com/en/articles/3116268-runway-on-linux)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -9,10 +9,7 @@
     * [Open RunwayML from Browser](how-to/web-link.md)
     * [Run Models Locally](how-to/run-models-locally.md)
     * [Use Your Own GPU (Linux Only)](how-to/local-gpu.md)
-    * Import Models
-        * [Tutorial](how-to/import-models.md)
-        * [Runway Python SDK](https://sdk.runwayml.com/)
-        * [Runway Model Template](https://github.com/runwayml/model-template)
+    * [Import Models](how-to/import-models.md)
     * Train Models - coming soon!
 
 * 🎨 Create with RunwayML

--- a/docs/how-to/chain-models-together.md
+++ b/docs/how-to/chain-models-together.md
@@ -1,5 +1,7 @@
 # How-To: Chain Models Together
 
+## Overview
+
 RunwayML makes it possible to use the output of one model as the input to another
 directly in the application interface.  Using this feature, you can make
 powerful workflows that chain together multiple models with minimal fuss and
@@ -89,7 +91,7 @@ input area of DenseDepth shows the image you just selected in StyleGAN, and the
 output area has the DenseDepth output inferred from the StyleGAN image.
 Success!
 
-## Tutorial 2: Reconstruct Drawings with Segmentations, im2txt and AttnGAN
+## Tutorial 2: Reconstructing Drawings with Segmentations, im2txt and AttnGAN
 
 Chaining two models isn't cool. You know what's cool? Chaining *three* models.
 Or more!

--- a/docs/how-to/chain-models-together.md
+++ b/docs/how-to/chain-models-together.md
@@ -31,7 +31,7 @@ We're working hard to make all of the models chaining friendly.
 You can read more about the kinds of data types that RunwayML supports in [the
 SDK documentation](https://sdk.runwayml.com/en/latest/).
 
-## Example 1: The Depths of Imaginary Bedrooms
+## Tutorial 1: The Depths of Imaginary Bedrooms
 
 As a simple example of model chaining, let's consider chaining together
 StyleGAN and DenseDepth. The StyleGAN model generates images from a latent
@@ -89,7 +89,7 @@ input area of DenseDepth shows the image you just selected in StyleGAN, and the
 output area has the DenseDepth output inferred from the StyleGAN image.
 Success!
 
-## Example 2: Reconstructing Drawings with Segmentations, im2txt and AttnGAN
+## Tutorial 2: Reconstruct Drawings with Segmentations, im2txt and AttnGAN
 
 Chaining two models isn't cool. You know what's cool? Chaining *three* models.
 Or more!

--- a/docs/how-to/import-models.md
+++ b/docs/how-to/import-models.md
@@ -1,34 +1,35 @@
-# How-To: Import Models into Runway
+# Import Models into RunwayML
 
-<div id="video-container">
-<iframe width="560" height="515" src="https://www.youtube.com/embed/m5EhZR9SFvc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
+## Overview
+RunwayML models are platform-agnostic; models written in any framework/language can be used by RunwayML as long as the model can be made accessible via an HTTP server. This process, however, is easiest in Python where we provide an SDK for parsing the inputs to the model, serializing its outputs, and setting up the server environment.
 
+A RunwayML model consists of an HTTP server that exposes a common interface over a network and a configuration file that specifies dependencies and build steps for running that server (and your model code) inside a Docker container. Both the network interface for interacting with the model and the Docker images created as a result of the configuration file are abstracted from the developer using the [RunwayML Model SDK](https://sdk.runwayml.com).
 
-Runway models are platform-agnostic; models written in any framework/language can be used by Runway as long as the model can be made accessible via an HTTP server. This process, however, is easiest in Python where we provide an SDK for parsing the inputs to the model, serializing its outputs, and setting up the server environment.
+Here are the steps involved in porting an ML model written in Python to RunwayML:
 
-A Runway model consists of an HTTP server that exposes a common interface over a network and a configuration file that specifies dependencies and build steps for running that server (and your model code) inside a Docker container. Both the network interface for interacting with the model and the Docker images created as a result of the configuration file are abstracted from the developer using the [Runway Model SDK](https://sdk.runwayml.com).
-
-Here are the steps involved in porting an ML model written in Python to Runway:
-
-1. Create a `runway_model.py` file which implements several methods from the [Runway Model SDK](https://sdk.runwayml.com).
+1. Create a `runway_model.py` file which implements several methods from the [RunwayML Model SDK](https://sdk.runwayml.com).
 2. Write a `runway.yml` config file.
 3. Upload your code to a GitHub repository.
-4. Import your new model into Runway using your GitHub account.
-5. Push new commits to your GitHub repo to trigger new model versions to be built and published on Runway.
+4. Import your new model into RunwayML using your GitHub account.
+5. Push new commits to your GitHub repo to trigger new model versions to be built and published on RunwayML.
 6. Add additional information to your model.
 7. (Optional) Add files to your model.
 8. (Optional) Make your model public!
 
-Once you've imported your model into Runway using your GitHub account, each `git push` will trigger the latest version of your code to be built and optionally deployed publicly through Runway.
+Once you've imported your model into RunwayML using your GitHub account, each `git push` will trigger the latest version of your code to be built and optionally deployed publicly through RunwayML.
 
+## Tutorial 1: Add Models to RunwayML
+This is a a two-part video series with Gene Kogan:
+<div id="video-container">
+<iframe width="560" height="515" src="https://www.youtube.com/embed/m5EhZR9SFvc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
 
-### Example: Adding SqueezeNet into Runway
-In this tutorial, we will demonstrate how to port the [SqueezeNet](https://arxiv.org/abs/1512.03385) computer vision model to Runway. We also provide a [Runway Model Template](https://github.com/runwayml/model-template) repository that contains boilerplate code for porting a new model.
+## Tutorial 2: Import the SqueezeNet Model
+In this tutorial, we will demonstrate how to port the [SqueezeNet](https://arxiv.org/abs/1512.03385) computer vision model to RunwayML. We also provide a [RunwayML Model Template](https://github.com/runwayml/model-template) repository that contains boilerplate code for porting a new model.
 
 We recommend forking the [`runwayml/model-squeezenet`](https://github.com/runwayml/model-squeezenet) GitHub repository to your own GitHub user account so that you can follow along with the tutorial.
 
-#### 1. Create a `runway_model.py` model server file
+### 1. Create a `runway_model.py` model server file
 
 SqueezeNet is a neural network architecture used for computer vision tasks, optimized for mobile/embedded devices. [PyTorch](https://github.com/pytorch/vision) includes an implementation of SqueezeNet pre-trained on ImageNet that can be used out-of-the-box for object recognition.
 
@@ -77,7 +78,7 @@ print(label)
 # lemon
 ```
 
-And here's the modified code for the same model wrapped in a server so that Runway can access it:
+And here's the modified code for the same model wrapped in a server so that RunwayML can access it:
 
 
 ```diff
@@ -121,13 +122,13 @@ preprocess = transforms.Compose([
 ```
 <p class='subtitle'>Contents of model.py</p>
 
-Behind the scenes, the Runway Python SDK uses the `@runway.command()` decorator to set up a server with a `/classify` endpoint that accepts a base64-encoded image. The SDK then converts this image into a `PIL.Image` before passing it to the `classify()` function, which classifies it and returns a text label.
+Behind the scenes, the RunwayML Python SDK uses the `@runway.command()` decorator to set up a server with a `/classify` endpoint that accepts a base64-encoded image. The SDK then converts this image into a `PIL.Image` before passing it to the `classify()` function, which classifies it and returns a text label.
 
-<p class="note"><b>NOTE:</b> You don't have to use the Runway Python SDK to set up the server. You can just use any server framework (e.g. Flask) and set up the classification endpoint manually. The SDK just makes things easier by taking care of parsing/serializing inputs/outputs and setting up the endpoints for you.</p>
+<p class="note"><b>NOTE:</b> You don't have to use the RunwayML Python SDK to set up the server. You can just use any server framework (e.g. Flask) and set up the classification endpoint manually. The SDK just makes things easier by taking care of parsing/serializing inputs/outputs and setting up the endpoints for you.</p>
 
-##### Testing your `runway_model.py` locally
+#### Testing your `runway_model.py` locally
 
-Before you configure your build environment and add your model to Runway, you should test it locally to make sure that it works as expected. Using Runway's Develop Mode, you can connect directly to your model server in order to test your model before building it remotely. Open your command line and type:
+Before you configure your build environment and add your model to RunwayML, you should test it locally to make sure that it works as expected. Using Runway's Develop Mode, you can connect directly to your model server in order to test your model before building it remotely. Open your command line and type:
 
 ```bash
 ## Optionally create and activate a Python 3 virtual environment
@@ -136,7 +137,7 @@ Before you configure your build environment and add your model to Runway, you sh
 pip install -r requirements.txt
 
 # Run the entrypoint script
-python runway_model.py
+python RunwayML_model.py
 ```
 
 You should see an output similar to this, indicating your model is running.
@@ -146,7 +147,7 @@ Setting up model...
 Starting model server at http://0.0.0.0:9000...
 ```
 
-You can now open Runway, and click the "From Server" button under "Create New Model."
+You can now open RunwayML, and click the "From Server" button under "Create New Model."
 
 ![Click "From Server"](assets/images/how-to/github-link/from-server.png)
 
@@ -156,13 +157,13 @@ After making sure that the Port under Server Options matches the port that your 
 
 ![Connect to model server](assets/images/how-to/github-link/dev-model-connect.png)
 
-You can now interact with your model using Runway. For example, try dragging an image in the Input area to see your model classify it:
+You can now interact with your model using RunwayML. For example, try dragging an image in the Input area to see your model classify it:
 
 ![Classify using your model server](assets/images/how-to/github-link/dev-model-classify.png)
 
-Once you've confirmed your model works correctly locally, you can create a `runway.yml` config file before building the model remotely with Runway + GitHub.
+Once you've confirmed your model works correctly locally, you can create a `runway.yml` config file before building the model remotely with RunwayML + GitHub.
 
-#### 2. Write a `runway.yml` config file
+### 2. Write a `runway.yml` config file
 
 Next you need to write a config file that defines the environment, dependencies, and build steps required to build and run our model. This file is written in [YAML](https://learnxinyminutes.com/docs/yaml/), a human-readable superset of JSON. Below is an example of the `runway.yml` file for Squeezenet:
 
@@ -174,9 +175,9 @@ build_steps:
   - pip install -r requirements.txt
 ```
 
-This file specifies the Python and CUDA versions to use, the entry point command which launches the Runway model and HTTP server, and a build step which installs the Python dependencies required to run our model. See the [Runway YAML reference page](https://sdk.runwayml.com/en/latest/runway_yaml_file.html) for a full list of config values supported in the `runway.yml` config file.
+This file specifies the Python and CUDA versions to use, the entry point command which launches the RunwayML model and HTTP server, and a build step which installs the Python dependencies required to run our model. See the [RunwayML YAML reference page](https://sdk.runwayml.com/en/latest/runway_yaml_file.html) for a full list of config values supported in the `runway.yml` config file.
 
-Peeking at the `requirements.txt` file reveals that the only dependencies for the SqueezeNet Runway model are PyTorch and PyTorch Vision, as well as the Runway Model SDK itself.
+Peeking at the `requirements.txt` file reveals that the only dependencies for the SqueezeNet RunwayML model are PyTorch and PyTorch Vision, as well as the RunwayML Model SDK itself.
 
 ```
 torch==1.0.0
@@ -188,31 +189,31 @@ runway-python
   <b>NOTE:</b> The <code>runway-python</code> module must always be installed via the <code>build_steps</code>. Failing to install this required dependency via the <code>runway.yml</code> file will cause all model builds to fail.
 </p>
 
-#### 3. Upload your code to a GitHub repository
+### 3. Upload your code to a GitHub repository
 
 Once your model has a `runway_model.py` and `runway.yml` config file it's time to upload your repository to GitHub. If you forked the `runway/model-squeezenet` repo at the beginning of this tutorial, you should already have a `git remote` that points to the forked repository on your GitHub user account. If you instead cloned the repo, or you started creating a model from scratch instead of using the `runwayml/model-squeezenet` repo, you should publish your code to GitHub as an open source repository now. For the remainder of this tutorial, we will assume the repository being ported is located at `https://github.com/YOUR_USERNAME/runway-model-tutorial`.
 
-#### 4. Import the model
+### 4. Import the model
 
-Once you've pushed your model to GitHub, it's time to import your model in the Runway. Open Runway and select the _Create New Model From GitHub_ button on the lower left.
+Once you've pushed your model to GitHub, it's time to import your model in the RunwayML. Open RunwayML and select the _Create New Model From GitHub_ button on the lower left.
 
 ![Import Model #1](assets/images/views/model-directory.png)
 
-Authorize Runway to access public data on your GitHub account.
+Authorize RunwayML to access public data on your GitHub account.
 
 ![Import Model #2](assets/images/how-to/github-link/github-01.png)
 
-Back in Runway, select the repository that contains your Runway model; `runway-model-tutorial` in our case.
+Back in RunwayML, select the repository that contains your RunwayML model; `runway-model-tutorial` in our case.
 
 ![Import Model #4](assets/images/how-to/github-link/github-03.png)
 
-#### 5. Push a new commit to trigger a build
+### 5. Push a new commit to trigger a build
 
-Once you've imported your model to Runway, you must push a new commit to GitHub to trigger a model build. When you do so, Runway will clone the code from your repository and use its `runway.yml` file to build a Docker image from your model. Each new commit pushed to the `master` branch of GitHub repository linked to a model will trigger a new model version to be built by Runway. Select the "Versions" tab in your model page to view all builds, past and present.
+Once you've imported your model to RunwayML, you must push a new commit to GitHub to trigger a model build. When you do so, RunwayML will clone the code from your repository and use its `runway.yml` file to build a Docker image from your model. Each new commit pushed to the `master` branch of GitHub repository linked to a model will trigger a new model version to be built by RunwayML. Select the "Versions" tab in your model page to view all builds, past and present.
 
 ![Import Model #6](assets/images/how-to/github-link/model-versions.png)
 
-Click on a model version to view details about the version builds. You will notice that the `default` switch is flipped automatically for the first build. This means that the model is now published by your Runway users and is available for others to use. You can set any successfully built version to be the `default` version, but you must have at least one default version. This is an intentional decision for the time being, as _Private Models_ is a feature that is still to come.
+Click on a model version to view details about the version builds. You will notice that the `default` switch is flipped automatically for the first build. This means that the model is now published by your RunwayML users and is available for others to use. You can set any successfully built version to be the `default` version, but you must have at least one default version. This is an intentional decision for the time being, as _Private Models_ is a feature that is still to come.
 
 ![Import Model #7](assets/images/how-to/github-link/logs.png)
 
@@ -220,9 +221,9 @@ You can view model logs during or after a build to debug your model build proces
 
 ![Import Model #8](assets/images/how-to/github-link/logs2.png)
 
-Once a model version has been successfully built you can add it to a workspace. You can also add any successful model versions to your personal workspace by hovering over the model version check mark in the "Versions" panel until it becomes a "+" icon, and then selecting it. This allows you to test new model versions before making them the default model version that is published to all Runway users.
+Once a model version has been successfully built you can add it to a workspace. You can also add any successful model versions to your personal workspace by hovering over the model version check mark in the "Versions" panel until it becomes a "+" icon, and then selecting it. This allows you to test new model versions before making them the default model version that is published to all RunwayML users.
 
-#### 6. Add information to your model
+### 6. Add information to your model
 
 Once you've imported your model, you can add additional information to help others understand the model. As the publisher of the model, you can do this from the model page using the **Edit Info** button. We recommend adding these fields for your model:
 
@@ -230,15 +231,15 @@ Once you've imported your model, you can add additional information to help othe
 * **Tagline**: A short one-line description of what your model does.
 * **Description**: A long description of what your model does. The description can be a paragraph or more and is interpreted as Markdown.
 * **Images**: A collection of images showcasing your model. The first image you add in the "Gallery" tab will be used as the thumbnail for the image.
-* **Attributions**: A list of names and respective roles for people or organizations that significantly contributed to a model. This usually includes authors or publishers of machine learning papers or frameworks. Be generous with attributions; give credit where credit is due. We intentionally differentiate between a model publisher (the Runway user that adds/publishes a model) and the original authors of the model code or paper. This provides flexibility and encourages remix, experimentation, and "forking" of models.
+* **Attributions**: A list of names and respective roles for people or organizations that significantly contributed to a model. This usually includes authors or publishers of machine learning papers or frameworks. Be generous with attributions; give credit where credit is due. We intentionally differentiate between a model publisher (the RunwayML user that adds/publishes a model) and the original authors of the model code or paper. This provides flexibility and encourages remix, experimentation, and "forking" of models.
 * **LICENSE**: The license defining how the model can be used.
-* **Keywords**: A list of tags that can be used to find your model in Runway.
+* **Keywords**: A list of tags that can be used to find your model in RunwayML.
 * **Performance Notes**: How can users expect the model to perform on GPU or CPU environments?
 * **Code, Paper, and More**: A list of links to resources related to your model, such as source code, arXiv papers, blog posts, or more.
 
-#### 7. (Optional) Add files to your model
+### 7. (Optional) Add files to your model
 
-Some models may require files that are too large to include in the Github repository, such model checkpoints. Runway provides a space to upload large files to include with your model. 
+Some models may require files that are too large to include in the Github repository, such model checkpoints. RunwayML provides a space to upload large files to include with your model. 
 
 To upload a model file, you need to specify a setup option in `runway_model.py` that has the [`runway.file`](https://sdk.runwayml.com/en/latest/data_types.html#runway.data_types.file) data type. For instance, if your model supports loading checkpoints in a Python pickle format (`.pkl`), you can add a setup option to your model for accepting pickle files in the following way:
 
@@ -261,22 +262,22 @@ Click "Choose File..." and select the file you want to upload, provide a name fo
 
 ![Import Model #10](assets/images/how-to/github-link/model-file-dialog.png)
 
-Once you have uploaded your file, you can now use that file with your model in Runway. Add your model to your workspace, and your file should appear in Options on the right hand side:
+Once you have uploaded your file, you can now use that file with your model in RunwayML. Add your model to your workspace, and your file should appear in Options on the right hand side:
 
 ![Import Model #11](assets/images/how-to/github-link/file-in-options.png)
 
-#### 8. (Optional) Make your model public!
+### 8. (Optional) Make your model public!
 
-Once you've successfully built and tested your model, and are satisfied with its results, you can make the model public, allowing anyone in the Runway community to use it and make projects with it! 
+Once you've successfully built and tested your model, and are satisfied with its results, you can make the model public, allowing anyone in the RunwayML community to use it and make projects with it! 
 
 To make your model public, select the "Settings" tab in your model page, and click on the "Make Public" button.
 
 ![Import Model #12](assets/images/how-to/github-link/make-public.png)
 
-### More Resources
+## RunwayML Python SDK
+Developer documentation for the Python SDK to port models: [RunwayML Model SDK Docs](https://sdk.runwayml.com)
 
-For more information about how to port a new or existing model to Runway, check out these resources:
+## RunwayML Model Template
+A boilerplate model template that you can use as a starting point to port models: [RunwayML Model Template](https://github.com/runwayml/model-template)
 
-* [Adding Models to RunwayML](https://www.youtube.com/playlist?list=PLj598ZXODDO_YUkKaBK9yBgIhOlPia_eL), a two-part video series with Gene Kogan
-* [Runway Model SDK Docs](https://sdk.runwayml.com), documentation for the Python SDK used to port models
-* [Runway Model Template](https://github.com/runwayml/model-template), a boilerplate model template that you can use as a starting point to port models
+

--- a/docs/how-to/import-models.md
+++ b/docs/how-to/import-models.md
@@ -18,13 +18,13 @@ Here are the steps involved in porting an ML model written in Python to RunwayML
 
 Once you've imported your model into RunwayML using your GitHub account, each `git push` will trigger the latest version of your code to be built and optionally deployed publicly through RunwayML.
 
-## Tutorial 1: Add Models to RunwayML
-This is a a two-part video series with Gene Kogan:
+## Tutorial 1: Adding Models to RunwayML
+This is a [two-part video series](https://www.youtube.com/playlist?list=PLj598ZXODDO_YUkKaBK9yBgIhOlPia_eL) with Gene Kogan:
 <div id="video-container">
 <iframe width="560" height="515" src="https://www.youtube.com/embed/m5EhZR9SFvc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-## Tutorial 2: Import the SqueezeNet Model
+## Tutorial 2: Importing the SqueezeNet Model
 In this tutorial, we will demonstrate how to port the [SqueezeNet](https://arxiv.org/abs/1512.03385) computer vision model to RunwayML. We also provide a [RunwayML Model Template](https://github.com/runwayml/model-template) repository that contains boilerplate code for porting a new model.
 
 We recommend forking the [`runwayml/model-squeezenet`](https://github.com/runwayml/model-squeezenet) GitHub repository to your own GitHub user account so that you can follow along with the tutorial.
@@ -275,9 +275,9 @@ To make your model public, select the "Settings" tab in your model page, and cli
 ![Import Model #12](assets/images/how-to/github-link/make-public.png)
 
 ## RunwayML Python SDK
-Developer documentation for the Python SDK to port models: [RunwayML Model SDK Docs](https://sdk.runwayml.com)
+Developer documentation for the Python SDK to import models: [RunwayML Model SDK Docs](https://sdk.runwayml.com)
 
 ## RunwayML Model Template
-A boilerplate model template that you can use as a starting point to port models: [RunwayML Model Template](https://github.com/runwayml/model-template)
+A boilerplate model template that you can use as a starting point to import models: [RunwayML Model Template](https://github.com/runwayml/model-template)
 
 


### PR DESCRIPTION
Minor changes to streamline sidebar navigation for the Importing Models resources in the Learn docs. No outside links to these resources will be impacted by the changes requested here. 

In addition, requesting similar updates to the Chain Models How-To to mirror the format for sidebar navigation. 