### PR TITLE
P5js CycleGAN attribution fix: Matthew Kenney

### DIFF
--- a/docs/networking/examples.md
+++ b/docs/networking/examples.md
@@ -92,7 +92,7 @@ This page provides tutorials and code examples to help you get started with your
 | Model | Description | Type | Source
 | :--- | :---| :--- | :--- |
 | AttnGAN | [Generate Images from Text](tutorials/tutorial_p5_attngan.md) | Tutorial |[Matthew Kenney](http://matthewkenney.site/) 🎉  |
-| CycleGAN | [Image Translation](tutorials/tutorial_p5_cyclegan.md) | Tutorial | [JP Yepez](https://www.jpyepez.com) 🎉 |
+| CycleGAN | [Image Translation](tutorials/tutorial_p5_cyclegan.md) | Tutorial | [Matthew Kenney](http://matthewkenney.site/) 🎉 |
 | GPT-2 | [Generate Text](https://github.com/runwayml/p5js/tree/master/GPT2) | Example | [Matthew Kenney](http://matthewkenney.site/) 🎉 |
 | im2text | [Generate Text from Images](https://github.com/runwayml/p5js/tree/master/im2txt) | Example | [Yining Shi](https://1023.io) 🎉 |
 | PhotoSketch | [Create Contour Drawings I with PhotoSketch](tutorials/tutorial_photosketch.md) | Tutorial  |  [JP Yepez](https://www.jpyepez.com) 🎉 |


### PR DESCRIPTION
Changed example attribution from "JP Yepez" to "Matthew Kenney"