### PR TITLE
Add note about Hosted models being experimental

### DIFF
--- a/docs/how-to/hosted-models.md
+++ b/docs/how-to/hosted-models.md
@@ -1,5 +1,7 @@
 # Hosted Models
 
+?> Hosted models are an experimental feature. Timeouts for POST requests against hosted models can vary greatly depending on a number of circumstances. As a result, we don't recommend using hosted models in any critical infrastructure or production code. We don't currently offer an SLA around model availability or request timeouts.
+
 Hosted Models allow you to create and deploy models as permanent URLs on the web. They provide you with a unique API endpoint that you can use to interact with them anytime, anywhere, without requiring RunwayML to be open!
 
 All RunwayML models can now be controlled and used over the internet as **Hosted Models**. This is useful for getting data in and out of RunwayML programmatically, integrating models with other tools and workflows, and providing control of models through scripting. Each Hosted Model is exposed via an API URL and is available to service requests at anytime.

--- a/docs/how-to/hosted-models.md
+++ b/docs/how-to/hosted-models.md
@@ -1,6 +1,6 @@
 # Hosted Models
 
-?> Hosted models are an experimental feature. Timeouts for POST requests against hosted models can vary greatly depending on a number of circumstances. As a result, we don't recommend using hosted models in any critical infrastructure or production code. We don't currently offer an SLA around model availability or request timeouts.
+?> Hosted models are an experimental feature. Response times for POST requests against hosted models can vary greatly depending on a number of circumstances. As a result, we don't recommend using hosted models in any critical infrastructure or production code. We don't currently offer an SLA around model availability or request timeouts.
 
 Hosted Models allow you to create and deploy models as permanent URLs on the web. They provide you with a unique API endpoint that you can use to interact with them anytime, anywhere, without requiring RunwayML to be open!
 


### PR DESCRIPTION
A user reached out asking if they could use hosted models for their client work. I caught that we're treating Hosted Models as experimental in [this message](https://runwayml-team.slack.com/archives/CEWCW5LDU/p1616712828158700). So thought to add a note (paraphrased from @brannondorsey's reply) to the docs as a disclaimer / to not mislead users.

![image](https://user-images.githubusercontent.com/17603754/112693435-854cf400-8ee5-11eb-9d16-a464cb735dfa.png)
